### PR TITLE
Senzing REST API Specification Version 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2020-10-01
+
+### Changed in 2.1.0
+
+- Added `SzMatchLevel` type to enumerate and describe the various match levels.
+- Added `matchLevel` field to `SzMatchInfo` to include the match level from
+  `MATCH_LEVEL_CODE` in the responses from the "why" endpoints.
+- Added `lastSeenTimestamp` field to `SzResolvedEntity` and `SzEntityRecord` to
+  include `LAST_SEEN_DT` field in the primary schema rather than only the raw.
+
 ## [2.0.0] - 2020-07-13
 
 ### Changed in 2.0.0

--- a/senzing-rest-api.yaml
+++ b/senzing-rest-api.yaml
@@ -3837,7 +3837,7 @@ components:
     SzHttpMethod:
       description: >-
         The HTTP method that was used for the operation.  The possible values
-        are"
+        are:
           * `GET` - An HTTP GET operation.
           * `POST` - An HTTP POST operation.
           * `PUT` - An HTTP PUT operation.
@@ -4230,6 +4230,11 @@ components:
             The identifier that uniquely identifies this record from other
             records from the same data source.  This may have been loaded with
             the record or automatically generated from the record's data.
+        lastSeenTimestamp:
+          description: >-
+            The timestamp that the record was most recently loaded or updated.
+          type: string
+          format: date-time
         addressData:
           description: >-
             An array of addresses associated with the record that are formatted
@@ -4571,6 +4576,12 @@ components:
             entities or if features are suppressed or if the minimal
             response flag has been specified.
           type: boolean
+        lastSeenTimestamp:
+          description: >-
+            The timestamp that the entity was last seen (i.e.: most recent
+            record was loaded).
+          type: string
+          format: date-time
     SzBaseRelatedEntity:
       description: >-
         Provides the additional fields to an SzResolvedEntity that describe
@@ -4626,6 +4637,27 @@ components:
         - POSSIBLE_MATCH
         - POSSIBLE_RELATION
         - DISCLOSED_RELATION
+    SzMatchLevel:
+      description: >-
+        Describes the various match levels describing how two records resolve
+        against each other.  The possible values are:
+          * `NO_MATCH` - No match was found between the records.
+          * `RESOLVED` - The records resolved to the same entity.
+          * `POSSIBLY_SAME` - The records were not close enough to resolve
+            but may represent the same entity if more data was provided.
+          * `POSSIBLY_RELATED` - The records share some attributes that
+            suggest a relationship.
+          * `NAME_ONLY` - The records match in name only.
+          * `DISCLOSED` - An explicit relationship has been disclosed between
+            the records.
+      type: string
+      enum:
+        - NO_MATCH
+        - RESOLVED
+        - POSSIBLY_SAME
+        - POSSIBLY_RELATED
+        - NAME_ONLY
+        - DISCLOSED
     SzRelatedEntity:
       description: >-
         Provides a description of an entity that is related to a
@@ -5317,16 +5349,21 @@ components:
             match key).
           nullable: false
           type: string
+        matchLevel:
+          description: >-
+            The match level describing how the records relate to each other.
+          nullable: false
+          $ref: '#/components/schemas/SzMatchLevel'
         resolutionRule:
           description: >-
             The resolution rule that triggered the match.
-          nullable: false
+          nullable: true
           type: string
         candidateKeys:
           description: >-
             The map of feature types to arrays of `SzCandidateKey` instances
             for that feature type.
-          nullable: false
+          nullable: true
           type: object
           additionalProperties:
             type: array
@@ -5336,7 +5373,7 @@ components:
           description: >-
             The map of feature types to arrays of `SzFeatureScore` instances
             for that feature type.
-          nullable: false
+          nullable: true
           type: object
           additionalProperties:
             type: array

--- a/senzing-rest-api.yaml
+++ b/senzing-rest-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Senzing REST API
-  version: "2.0.0"
+  version: "2.1.0"
   description: >-
     This is the Senzing REST API.  It describes the REST interface
     to Senzing API functions available via REST.  It leverages the


### PR DESCRIPTION
- Added `SzMatchLevel` type to enumerate and describe the various match levels.
- Added `matchLevel` field to `SzMatchInfo` to include the match level from`MATCH_LEVEL_CODE` in the responses from the "why" endpoints.
- Added `lastSeenTimestamp` field to `SzResolvedEntity` and `SzEntityRecord` to include `LAST_SEEN_DT` field in the primary schema rather than only the raw.
