### PR TITLE
Version 2.1.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed in 2.1.1
 
-- Added the NOT_SCORED value for SzScoringBucket enum.
+- Added the `NOT_SCORED` value for `SzScoringBucket` enum.
 
 ## [2.1.0] - 2020-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2020-10-06
+
+### Changed in 2.1.1
+
+- Added the NOT_SCORED value for SzScoringBucket enum.
+
 ## [2.1.0] - 2020-10-01
 
 ### Changed in 2.1.0

--- a/senzing-rest-api.yaml
+++ b/senzing-rest-api.yaml
@@ -5246,6 +5246,7 @@ components:
         Describes the scoring bucket that a feature score falls into.  The
         range of scores constitute different buckets depending on the feature
         type..  The possible values are:
+            * `NOT_SCORED` - The respective features were not scored.
             * `SAME` - The two feature values are considered to be the same.
             * `CLOSE` - The two feature values are considered to be close.
             * `LIKELY` - The two feature values are similar, but not enough to
@@ -5258,6 +5259,7 @@ components:
                             values.
       type: string
       enum:
+        - NOT_SCORED
         - SAME
         - CLOSE
         - LIKELY


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

This is related to the Senzing API Server Issue #191 -- it adds the NOT_SCORED value to the specification as well.

## Why was change needed

Customer urgent need.

## What does change improve

Adds unhandled enumeration value for SzScoringBucket (i.e.: "NOT_SCORED")
