### PR TITLE
Senzing REST API Specification Version 2.2.0 Upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2020-10-15
+
+### Changed in 2.2.0
+
+- Added `SzNameScoring` to describe name scoring details
+- Added `SzSearchFeatureScore` for search feature scores
+- Modified `SzBaseRelatedEntity` to remove `fullNameScore` field since it has
+not been populated since switch to version 2.0.0 of native Senzing SDK and
+never made sense in the "base class" since only `SzAttributeSearchResult` had
+this field populated under native Senzing SDK version 1.x.
+- Added `bestNameScore` field to `SzAttributeSearchResult` to replace
+`fullNameScore` in the place where the name score was previously
+used with version 1.x of the native Senzing SDK (i.e.: to sort search results
+based on the strength of the name match).
+- Modified `SzAttributeSearchResult` to include the `featureScores` field to
+provide feature scores without using "raw data"
+- Added `nameScoringDetails` field to `SzFeatureScore` class to provide
+`SzNameScoring` name scoring details on why operations,
+- Updated `com.senzing.api.model.SzFeatureScore` to define its `score` field as 
+the most sensible score value from the `nameScoringDetails` for `"NAME"`
+features since the `FULL_SCORE` field is not available for names.
+- Updated version numbers to 2.2.0
+
 ## [2.1.1] - 2020-10-06
 
 ### Changed in 2.1.1

--- a/senzing-rest-api.yaml
+++ b/senzing-rest-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Senzing REST API
-  version: "2.1.0"
+  version: "2.2.0"
   description: >-
     This is the Senzing REST API.  It describes the REST interface
     to Senzing API functions available via REST.  It leverages the

--- a/senzing-rest-api.yaml
+++ b/senzing-rest-api.yaml
@@ -4597,13 +4597,6 @@ components:
                 matched to the primary resolved entity.
               type: integer
               format: int32
-            fullNameScore:
-              description: >-
-                The full name score between the primary resolved entity and
-                this related entity.  The higher the score the closer the
-                name match.
-              type: integer
-              format: int32
             matchScore:
               description: >-
                 The match score between the primary resolved entity and
@@ -4716,6 +4709,25 @@ components:
           properties:
             resultType:
               $ref: '#/components/schemas/SzAttributeSearchResultType'
+            bestNameScore:
+              description: >-
+                The best name score between the search criteria and this
+                matched search entity.  The higher the score the closer the
+                name match.  This uses either the full name score or
+                organization name score.  If none exist then this filed is
+                omitted.
+              type: integer
+              format: int32
+            featureScores:
+              description: >-
+                The map of feature types to arrays of `SzSearchFeatureScore`
+                instances for that feature type.
+              nullable: true
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SzSearchFeatureScore'
             relatedEntities:
               description: >-
                 The array of RelatedEntity instances describing the possible
@@ -5288,6 +5300,44 @@ components:
           description: >-
             The usage type assigned to the feature value.
           type: string
+    SzNameScoring:
+      description: >-
+        Describes the scoring details between two names.
+      type: object
+      properties:
+        fullNameScore:
+          description: >-
+            The full name score.  This field is omitted if there is not a
+            full name score (e.g.: with an organization name)
+          type: integer
+          format: int32
+        surnameScore:
+          description: >-
+            The surname score.  This field is omitted if there is not a
+            surname score (e.g.: with an organization name or if there were no
+            surnames to compare)
+          type: integer
+          format: int32
+        givenNameScore:
+          description: >-
+            The given name score.  This field is omitted if there is not a
+            given name score (e.g.: with an organization name or if there were
+            no given names to compare)
+          type: integer
+          format: int32
+        generationScore:
+          description: >-
+            The generation match score.  This field is omitted if there is not a
+            generation match score (e.g.: with an organization name or if there
+            were no generations to compare)
+          type: integer
+          format: int32
+        orgNameScore:
+          description: >-
+            The organization name score.  This field is omitted if there is not
+            a organization name score (e.g.: with an personal name)
+          type: integer
+          format: int32
     SzFeatureScore:
       description: >-
         Describes the scoring between two `SzScoredFeature` instances.
@@ -5309,9 +5359,18 @@ components:
         score:
           description: >-
             The integer score between the two feature values (typically from 0
-            to 100)
+            to 100).  If this is a name feature, then this value is the "best"
+            value from the `SzNameScoring` instance described by
+            `nameScoringDetails` (in order of precedence the first of these
+            values that exists: `orgNameScore`, `fullNameScore`,
+            `surnameScore` and then `givenNameScore`).
           type: integer
           format: int32
+        nameScoringDetails:
+          description: >-
+            The name scoring values if this score is for a name feature.  This
+            property is omitted if not a name feature.
+          $ref: '#/components/schemas/SzNameScoring'
         scoringBucket:
           description: >-
             The `SzScoringBucket` describing the meaning of the `score`.
@@ -5321,6 +5380,39 @@ components:
             The `SzScoringBehavior` describing the scoring behavior for the
             features.
           $ref: '#/components/schemas/SzScoringBehavior'
+    SzSearchFeatureScore:
+      description: >-
+        Describes the scoring between two search features.
+      type: object
+      properties:
+        featureType:
+          description: >-
+            The feature type of the features being scored.
+          type: string
+        inboundFeature:
+          description: >-
+            The inbound feature value as a string.
+          type: string
+        candidateFeature:
+          description: >-
+            The feature value that was a candidate match for the inbound
+            feature as a string.
+          type: string
+        score:
+          description: >-
+            The integer score between the two feature values (typically from 0
+            to 100).  If this is a name feature, then this value is the "best"
+            value from the `SzNameScoring` instance described by
+            `nameScoringDetails` (in order of precedence the first of these
+            values that exists: `orgNameScore`, `fullNameScore`,
+            `surnameScore` and then `givenNameScore`).
+          type: integer
+          format: int32
+        nameScoringDetails:
+          description: >-
+            The name scoring values if this score is for a name feature.  This
+            property is omitted if not a name feature.
+          $ref: '#/components/schemas/SzNameScoring'
     SzCandidateKey:
       description: >-
         Describes a candidate key that triggered the scoring of two entities.
@@ -5446,6 +5538,7 @@ components:
             The `SzMatchInfo` providing the details of the result.
           nullable: false
           $ref: '#/components/schemas/SzMatchInfo'
+
 tags:
   - name: Admin
     description: Administrative operations.

--- a/senzing-rest-api.yaml
+++ b/senzing-rest-api.yaml
@@ -5538,7 +5538,6 @@ components:
             The `SzMatchInfo` providing the details of the result.
           nullable: false
           $ref: '#/components/schemas/SzMatchInfo'
-
 tags:
   - name: Admin
     description: Administrative operations.


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

- Zendesk Ticket #3020 - Add feature scores to search results without having to use `withRaw=true` query parameter
- Bug: Remove `fullNameScore` from `SzBaseRelatedEntity` base-class since it has not been populated since 2.0 upgrade and is omitted if not available anyway (it was only ever included for the sub-class `SzAttributeSearchResult`).   Replace the removed field with the `bestNameScore` field on `SzAttributeSearchResult` sub-class where it was actually used.
- Enhancement: Include `SzNameScoring` (new class to describe name scoring details) on `SzFeatureScore` for "why" operations similar to how it is included in `SzSearchFeatureScore` in resolution of Zendesk #3020
- Bug:`SzFeatureScore` did not accurately describe the `score` field for "NAME" features which have more than one score.  This is now defined as being one of the name scores according to an order of precedence and `nameScoringDetails` is added provide the breakdown of the name scores.

## Why was change needed

- Users had to rely on `?withRaw=true` to get the feature scores on search results -- this should be part of the primary data model.
- The `fullNameScore` field was useless since the upgrade to Senzing native SDK 2.0 and was only ever used on `SzAttributeSearchResult` anyway in SDK version 1.x -- this is a correction to the model.

## What does change improve

- Additional fidelity on search with feature scores and name scoring details
- New `bestNameScore` on search results for sorting by best name match 
- Cleanup of ambiguous unused field 
- Name scoring details on "why" operations.

NOTE: Despite removing the `SzBaseRelatedEntity.fullNameScore` field we did not increment the version number to 3.0 because the field "fullNameScore" was documented to be omitted when not available (i.e.: "optional") and has been omitted 100% of the time since moving to 2.0 due to bugs in the API Server implementation.  While the specification should technically be updated to version 3.0.0 for other "hypothetical" implementations of the Senzing REST API Specification, to our knowledge the Senzing API Server is the defacto implementation and the only implementation we know of that is in use.