### PR TITLE
Removed extranneous 'type: string' in 'SzFlaggedRecord.dataSource' description.

### DIFF
--- a/senzing-rest-api.yaml
+++ b/senzing-rest-api.yaml
@@ -4239,7 +4239,6 @@ components:
         dataSource:
           description: >-
             The data source code associated with the sample record.
-            type: string
           type: string
         recordId:
           description: >-


### PR DESCRIPTION
Documentation fix the looks like it was created from a copy/paste error.