### PR TITLE
Additional change to update README.md for link to 2.3.0 as a "previous version"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Viewing the Senzing REST API OpenAPI specification:
 
 View previous versions of the Senzing REST API OpenAPI specification:
 
+- [Version 2.3.0](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Senzing/senzing-rest-api-specification/2.3.0/senzing-rest-api.yaml)
 - [Version 2.2.0](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Senzing/senzing-rest-api-specification/2.2.0/senzing-rest-api.yaml)
 - [Version 2.1.1](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Senzing/senzing-rest-api-specification/2.1.1/senzing-rest-api.yaml)
 - [Version 2.1.0](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Senzing/senzing-rest-api-specification/2.1.0/senzing-rest-api.yaml)


### PR DESCRIPTION
Forgot to update the README.md to provide a link to the Swagger docs for version 2.3.0 under the "previous versions" documentation.