### PR TITLE
Updated README.md to add link to documentation of version 2.6.0 as prior version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Viewing the Senzing REST API OpenAPI specification:
 
 View previous versions of the Senzing REST API OpenAPI specification:
 
+- [Version 2.6.0](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Senzing/senzing-rest-api-specification/2.6.0/senzing-rest-api.yaml)
 - [Version 2.5.0](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Senzing/senzing-rest-api-specification/2.5.0/senzing-rest-api.yaml)
 - [Version 2.4.0](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Senzing/senzing-rest-api-specification/2.4.0/senzing-rest-api.yaml)
 - [Version 2.3.0](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Senzing/senzing-rest-api-specification/2.3.0/senzing-rest-api.yaml)


### PR DESCRIPTION
Simple update to README.md to reference version 2.6.0 documentation now that we are releasing 2.7.0