### PR TITLE
Updates for bulk-data operation examples to handle errant example text escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.1] - 2022-01-12
+
+### Changed in 2.7.1
+
+- Changes to bulk-data operation examples for improved documentation
+
 ## [2.7.0] - 2021-07-22
 
 ### Changed in 2.7.0

--- a/senzing-rest-api.yaml
+++ b/senzing-rest-api.yaml
@@ -2781,7 +2781,6 @@ paths:
           application/json; charset=UTF-8:
             schema:
               type: object
-              nullable: true
               additionalProperties: {}
             examples:
               chooseExample:
@@ -2791,7 +2790,6 @@ paths:
           application/json:
             schema:
               type: object
-              nullable: true
               additionalProperties: {}
             examples:
               chooseExample:
@@ -3238,7 +3236,6 @@ paths:
           application/json; charset=UTF-8:
             schema:
               type: object
-              nullable: true
               additionalProperties: {}
             examples:
               chooseExample:
@@ -3248,7 +3245,6 @@ paths:
           application/json:
             schema:
               type: object
-              nullable: true
               additionalProperties: {}
             examples:
               chooseExample:

--- a/senzing-rest-api.yaml
+++ b/senzing-rest-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Senzing REST API
-  version: "2.7.0"
+  version: "2.7.1"
   description: >-
     This is the Senzing REST API.  It describes the REST interface
     to Senzing API functions available via REST.  It leverages the
@@ -2742,54 +2742,6 @@ paths:
           the [Senzing Generic Entity Specification](https://senzing.zendesk.com/hc/en-us/articles/231925448-Generic-Entity-Specification).
         required: true
         content:
-          application/x-jsonlines; charset=UTF-8:
-            schema:
-              type: string
-            examples:
-              chooseExample:
-                $ref: '#/components/examples/chooseExample'
-              bulkDataJsonLinesExample:
-                $ref: '#/components/examples/bulkDataJsonLinesExample'
-          application/x-jsonlines:
-            schema:
-              type: string
-            examples:
-              chooseExample:
-                $ref: '#/components/examples/chooseExample'
-              bulkDataJsonLinesExample:
-                $ref: '#/components/examples/bulkDataJsonLinesExample'
-          application/json; charset=UTF-8:
-            schema:
-              type: string
-            examples:
-              chooseExample:
-                $ref: '#/components/examples/chooseExample'
-              bulkDataJsonExample:
-                $ref: '#/components/examples/bulkDataJsonExample'
-          application/json:
-            schema:
-              type: string
-            examples:
-              chooseExample:
-                $ref: '#/components/examples/chooseExample'
-              bulkDataJsonExample:
-                $ref: '#/components/examples/bulkDataJsonExample'
-          text/csv; charset=UTF-8:
-            schema:
-              type: string
-            examples:
-              chooseExample:
-                $ref: '#/components/examples/chooseExample'
-              bulkDataCSVExample:
-                $ref: '#/components/examples/bulkDataCSVExample'
-          text/csv:
-            schema:
-              type: string
-            examples:
-              chooseExample:
-                $ref: '#/components/examples/chooseExample'
-              bulkDataCSVExample:
-                $ref: '#/components/examples/bulkDataCSVExample'
           text/plain; charset=UTF-8:
             schema:
               type: string
@@ -2814,6 +2766,54 @@ paths:
                 $ref: '#/components/examples/bulkDataJsonLinesExample'
               bulkDataJsonExample:
                 $ref: '#/components/examples/bulkDataJsonExample'
+          application/x-jsonlines; charset=UTF-8:
+            schema:
+              type: string
+            examples:
+              seeTextPlainExample:
+                $ref: '#/components/examples/seeTextPlainExamples'
+          application/x-jsonlines:
+            schema:
+              type: string
+            examples:
+              seeTextPlainExample:
+                $ref: '#/components/examples/seeTextPlainExamples'
+          application/json; charset=UTF-8:
+            schema:
+              type: object
+              nullable: true
+              additionalProperties: {}
+            examples:
+              chooseExample:
+                $ref: '#/components/examples/chooseExample'
+              bulkDataJsonExample:
+                $ref: '#/components/examples/bulkDataJsonExample'
+          application/json:
+            schema:
+              type: object
+              nullable: true
+              additionalProperties: {}
+            examples:
+              chooseExample:
+                $ref: '#/components/examples/chooseExample'
+              bulkDataJsonExample:
+                $ref: '#/components/examples/bulkDataJsonExample'
+          text/csv; charset=UTF-8:
+            schema:
+              type: string
+            examples:
+              chooseExample:
+                $ref: '#/components/examples/chooseExample'
+              bulkDataCSVExample:
+                $ref: '#/components/examples/bulkDataCSVExample'
+          text/csv:
+            schema:
+              type: string
+            examples:
+              chooseExample:
+                $ref: '#/components/examples/chooseExample'
+              bulkDataCSVExample:
+                $ref: '#/components/examples/bulkDataCSVExample'
           multipart/form-data:
             schema:
               type: object
@@ -3199,54 +3199,6 @@ paths:
           the [Senzing Generic Entity Specification](https://senzing.zendesk.com/hc/en-us/articles/231925448-Generic-Entity-Specification).
         required: true
         content:
-          application/x-jsonlines; charset=UTF-8:
-            schema:
-              type: string
-            examples:
-              chooseExample:
-                $ref: '#/components/examples/chooseExample'
-              bulkDataJsonLinesExample:
-                $ref: '#/components/examples/bulkDataJsonLinesExample'
-          application/x-jsonlines:
-            schema:
-              type: string
-            examples:
-              chooseExample:
-                $ref: '#/components/examples/chooseExample'
-              bulkDataJsonLinesExample:
-                $ref: '#/components/examples/bulkDataJsonLinesExample'
-          application/json; charset=UTF-8:
-            schema:
-              type: string
-            examples:
-              chooseExample:
-                $ref: '#/components/examples/chooseExample'
-              bulkDataJsonExample:
-                $ref: '#/components/examples/bulkDataJsonExample'
-          application/json:
-            schema:
-              type: string
-            examples:
-              chooseExample:
-                $ref: '#/components/examples/chooseExample'
-              bulkDataJsonExample:
-                $ref: '#/components/examples/bulkDataJsonExample'
-          text/csv; charset=UTF-8:
-            schema:
-              type: string
-            examples:
-              chooseExample:
-                $ref: '#/components/examples/chooseExample'
-              bulkDataCSVExample:
-                $ref: '#/components/examples/bulkDataCSVExample'
-          text/csv:
-            schema:
-              type: string
-            examples:
-              chooseExample:
-                $ref: '#/components/examples/chooseExample'
-              bulkDataCSVExample:
-                $ref: '#/components/examples/bulkDataCSVExample'
           text/plain; charset=UTF-8:
             schema:
               type: string
@@ -3271,6 +3223,54 @@ paths:
                 $ref: '#/components/examples/bulkDataJsonLinesExample'
               bulkDataJsonExample:
                 $ref: '#/components/examples/bulkDataJsonExample'
+          application/x-jsonlines; charset=UTF-8:
+            schema:
+              type: string
+            examples:
+              seeTextPlainExample:
+                $ref: '#/components/examples/seeTextPlainExamples'
+          application/x-jsonlines:
+            schema:
+              type: string
+            examples:
+              seeTextPlainExample:
+                $ref: '#/components/examples/seeTextPlainExamples'
+          application/json; charset=UTF-8:
+            schema:
+              type: object
+              nullable: true
+              additionalProperties: {}
+            examples:
+              chooseExample:
+                $ref: '#/components/examples/chooseExample'
+              bulkDataJsonExample:
+                $ref: '#/components/examples/bulkDataJsonExample'
+          application/json:
+            schema:
+              type: object
+              nullable: true
+              additionalProperties: {}
+            examples:
+              chooseExample:
+                $ref: '#/components/examples/chooseExample'
+              bulkDataJsonExample:
+                $ref: '#/components/examples/bulkDataJsonExample'
+          text/csv; charset=UTF-8:
+            schema:
+              type: string
+            examples:
+              chooseExample:
+                $ref: '#/components/examples/chooseExample'
+              bulkDataCSVExample:
+                $ref: '#/components/examples/bulkDataCSVExample'
+          text/csv:
+            schema:
+              type: string
+            examples:
+              chooseExample:
+                $ref: '#/components/examples/chooseExample'
+              bulkDataCSVExample:
+                $ref: '#/components/examples/bulkDataCSVExample'
           multipart/form-data:
             schema:
               type: object
@@ -3311,10 +3311,19 @@ components:
   examples:
     chooseExample:
       summary: -- choose an example --
-      value:
+      value: >-
+
+    seeTextPlainExamples:
+      summary: -- see text/plain examples for JSON-lines --
+      value: >-
+        JSON-lines examples with content type application/x-jsonlines do not
+        render properly in Swagger UI as they are escaped as JSON strings.
+        Choose the various text/plain content types to see them correctly.
+
     noDataSources:
       summary: No data sources in content body
-      value:
+      value: >-
+
     singleDataSourceUnquotedString:
       summary: Single data source as an unquoted string
       value: >-


### PR DESCRIPTION
Example text for request bodies of bulk data operations non-text media types was being escaped as a JSON string (specifically `application/x-jsonlines` and `application/json` as well as the UTF-8 variants).

- Modified the `application/json` media type examples to specify generic JSON
- Modified the `application/x-jsonlines` media type examples to refer users to the `text/plain` examples
- Modified example ordering so `text/plain` comes first

