### PR TITLE
Updates for version 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2022-09-23
+
+### Changed in 3.3.0
+
 ## [3.2.0] - 2022-08-17
+
+- Added `SzDetailLevel.BARE_MINIMAL` value to handle just returning the
+  entity ID's without record information or relationship match info.
+- Added `SzDetailLevel.NETWORM_MINIMAL` value to behave the same as 
+  `SzDetailLevel.BARE_MINIMAL`, but with the addition of relationship
+  match info in the case of related entities being included.
+- Added `SzFeatureMode.ENTITY_NAME_ONLY` to handle just retrieving the 
+  entity name without actually returning other features.
 
 ### Changed in 3.2.0
 

--- a/senzing-rest-api.yaml
+++ b/senzing-rest-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Senzing REST API
-  version: "3.2.0"
+  version: "3.3.0"
   description: >-
     This is the Senzing REST API.  It describes the REST interface
     to Senzing API functions available via REST.  It leverages the
@@ -4120,6 +4120,9 @@ components:
           * `NONE` - Do not include any feature values -- this is the fastest
                      option from a performance perspective because feature
                      values do not have to be retrieved.
+          * `ENTITY_NAME_ONLY` - Same as `NONE` in that no "features" are
+                                 returned, but the singular entity name value
+                                 is determined will be determined and returned.
           * `REPRESENTATIVE` - Include only a single representative value per
                                "unique" value of a feature.  If there are
                                multiple values that are near duplicates then
@@ -4136,6 +4139,7 @@ components:
       type: string
       enum:
         - NONE
+        - ENTITY_NAME_ONLY
         - REPRESENTATIVE
         - WITH_DUPLICATES
         - ATTRIBUTED
@@ -4200,6 +4204,14 @@ components:
         the various endpoints that return entity data.  Details for features of
         entities as well as the related entities of entities are controlled by
         other flags.  Possible values are:
+          * `BARE_MINIMAL` - The entities returned will include only their
+                             entity ID's.  No record information is returned
+                             and if related entities are included, they too will
+                             only be described by their entity ID's and will
+                             **not** include any matching info.
+          * `NETWORK_MINIMAL` - Identical to `BARE_MINIMAL` except in the case
+                                of related entities being included they will
+                                also include related matching info.
           * `MINIMAL` - The entities returned will include at most their
                         entity ID's as well as identifiers for their
                         constituent records (i.e.: data source code and record
@@ -4228,6 +4240,8 @@ components:
                         expected to a user).
       type: string
       enum:
+        - BARE_MINIMAL
+        - NETWORK_MINIMAL
         - MINIMAL
         - BRIEF
         - SUMMARY
@@ -4907,8 +4921,9 @@ components:
             recordSummary items may be missing the topRecordIds if partial
             is true.  This can be true for partially retrieved related
             entities or if features are suppressed, if the detail level has
-            has suppressed records or if the force-minimal response flag has
-            been specified.
+            suppressed records or related matching info (in the case of related
+            entities) or if the force-minimal response flag has been been
+            specified.
           type: boolean
         lastSeenTimestamp:
           description: >-


### PR DESCRIPTION
- Added `SzDetailLevel.BARE_MINIMAL` value to handle just returning the
  entity ID's without record information or relationship match info.
- Added `SzDetailLevel.NETWORM_MINIMAL` value to behave the same as 
  `SzDetailLevel.BARE_MINIMAL`, but with the addition of relationship
  match info in the case of related entities being included.
- Added `SzFeatureMode.ENTITY_NAME_ONLY` to handle just retrieving the 
  entity name without actually returning other features.

Resolves Issue #83 